### PR TITLE
Support use-machine in React Context

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "0.4.0",
   "description": "Use Statecharts in React powered by XState",
   "main": "lib/index.js",
-  "files": [
-    "lib/"
-  ],
+  "files": ["lib/"],
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Awesome library! I started using in my project but quickly ran into an issue with React Context.

If use-machine is used in React Context Provider, a child Consumer may mount before the Provider finishes running its effects. So, if a child called `send(...)` before the Provider's effects finish (like on mount), then the event will either be lost or `send` will be undefined.

This change is basically switching from `useEffect` to `useMemo` to setup the interpreter so the service does not wait for the component to mount before it's available. I think we're also skip an initial rerender this way.
