### PR TITLE
Make peerDependencies a semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "react": "16.8.1",
-    "react-dom": "16.8.1",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "xstate": "^4.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The peer dependencies on react and react-dom are specified as specific
versions, so you get warnings if trying to use it on the latest.
I suspect you didn't want it to be that way, so here is a PR to fix
it.
Feel free to just close this if you *did* want it that way for some reason..