### PR TITLE
Refactor useMachine

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,66 +7,52 @@ import {
   OmniEvent,
   State,
   StateSchema,
-  DefaultContext,
+  DefaultContext
 } from "xstate";
 import { interpret, Interpreter } from "xstate/lib/interpreter";
 
 export function useMachine<
   TStateSchema extends StateSchema,
   TEvent extends EventObject = EventObject,
-  TContext = DefaultContext,
-  >(
-    config: MachineConfig<TContext, TStateSchema, TEvent>,
-    options: Partial<MachineOptions<TContext, TEvent>>,
-    initialContext?: TContext
-  ): TCreateContext<TContext, TStateSchema, TEvent> {
+  TContext = DefaultContext
+>(
+  config: MachineConfig<TContext, TStateSchema, TEvent>,
+  options: Partial<MachineOptions<TContext, TEvent>>,
+  initialContext: TContext
+): TCreateContext<TContext, TStateSchema, TEvent> {
   const machine = useMemo(
-    () => Machine<TContext, TStateSchema, TEvent>(config, options, initialContext),
+    () =>
+      Machine<TContext, TStateSchema, TEvent>(config, options, initialContext),
     []
   );
-
-  const [state, setStateSchema] = useState<State<TContext, TEvent>>(
-    machine.initialState
-  );
-  const [context, setContext] = useState<TContext>(machine.context!);
-
-  const serviceRef = useRef<Interpreter<TContext, TStateSchema, TEvent>>(null);
-
-  // Service is created lazily once
-  function getService() {
-    const service = serviceRef.current;
-    if (service !== null) {
-      return service;
-    }
-    const newService = interpret<TContext, TStateSchema, TEvent>(machine);
-    // workaround https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
-    ; (serviceRef.current as any) = newService;
-    newService.onTransition(state => setStateSchema(state));
-    newService.onChange(context => setContext(context));
-    // call init after the above callbacks are set so any immediate actions
-    // are reflected in react's state
-    newService.init();
-    return newService;
-  }
+  const [state, setState] = useState(machine.initialState);
+  const [context, setContext] = useState(initialContext);
+  const service = useMemo(() => {
+    const service = interpret(machine);
+    service.onTransition(setState);
+    service.onChange(setContext);
+    service.init();
+    return service;
+  }, [machine]);
 
   // Stop the service when unmounting.
   useEffect(() => {
-    return () => void getService().stop();
-  }, []);
+    return () => void service.stop();
+  }, [service]);
 
-  return { state, send: getService().send, context, service: getService() };
+  return { state, send: service.send, context, service };
 }
 
 export type TCreateContext<
   TContext,
   TStateSchema,
   TEvent extends EventObject
-  > = {
-    state: State<TContext, TEvent>
-    context: TContext
-    send: TSendFn<TContext, TEvent>
-    service: Interpreter<TContext, TStateSchema, TEvent>
-  }
+> = {
+  state: State<TContext, TEvent>;
+  context: TContext;
+  send: TSendFn<TContext, TEvent>;
+  service: Interpreter<TContext, TStateSchema, TEvent>;
+};
 
 type TSendFn<TContext, TEvent extends EventObject> = (
   event: OmniEvent<TEvent>


### PR DESCRIPTION
- Remove `!` by using initialContext instead of machine.context
- Replace useRef with useMemo and avoid workaround and 3 function calls
- All tests are still green
- Add dependencies to hooks

It seems that this approach was used earlier and [then refactored to `useRef` + function](https://github.com/carloslfu/use-machine/commit/b2e5de5446c63e5e91a43663934359b5c1d5392f). What was the reason for this change?